### PR TITLE
Print "X out of Y patches applied" if ply abort is invoked during conflict

### DIFF
--- a/plypatch/__init__.py
+++ b/plypatch/__init__.py
@@ -543,7 +543,7 @@ class WorkingRepo(git.Repo):
         if total_no_of_patches == len(applied_patches):
             return 'all-patches-applied'
 
-        return "%d out of %d patches applied" % (len(
+        return "%d-out-of-%d-patches-applied" % (len(
             applied_patches), total_no_of_patches)
 
     def check_patch_repo(self):

--- a/plypatch/cli.py
+++ b/plypatch/cli.py
@@ -230,8 +230,10 @@ class StatusCommand(CLICommand):
             die('Restore in progress, use skip or resolve to continue')
         elif status == 'no-patches-applied':
             die('No patches applied')
-        else:
+        elif status == 'all-patches-applied':
             die('All patches applied')
+        else:
+            die(status.replace('-', ' ') + ". Restore aborted")
 
 
 class UnlinkCommand(CLICommand):

--- a/tests/functional/test_everything.py
+++ b/tests/functional/test_everything.py
@@ -448,7 +448,7 @@ class FunctionalTestCase(unittest.TestCase):
 
         self.working_repo.abort()
 
-        self.assertEqual("1 out of 2 patches applied", self.working_repo
+        self.assertEqual("1-out-of-2-patches-applied", self.working_repo
             .status)
 
 


### PR DESCRIPTION
This patch tries to fix the following issue. 
1. Run ply resolve.
2. Assume there is a conflict. Run ply abort
3. Run ply status. Ply will say All patches applied"

I changed it to say "X out of Y patches applied" where X and Y are the numer of patches applied and the total number of patches to be applied.
