### PR TITLE
Remove execfile() from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import setuptools
 
-
-execfile('plypatch/version.py')
+from plypatch.version import __version__
 
 
 setuptools.setup(


### PR DESCRIPTION
This method has been removed in Python 3, use a regular import
instead.
