### PR TITLE
Allow users to skip the cleanup commit on restore

### DIFF
--- a/plypatch/__init__.py
+++ b/plypatch/__init__.py
@@ -295,7 +295,8 @@ class WorkingRepo(Repo):
             raise exc.GitConfigRequired('user.name')
 
     def restore(self, three_way_merge=True, commit_msg=None,
-                fetch_remotes=True, customize_commit_msg=False):
+                fetch_remotes=True, customize_commit_msg=False,
+                no_commit=False):
         """Applies a series of patches to the working repo's current
         branch.
         """
@@ -384,7 +385,9 @@ class WorkingRepo(Repo):
         template = None
 
         # Determine whether we need to prompt the user to edit commit message
-        if commit_msg:
+        if no_commit:
+            pass
+        elif commit_msg:
             if customize_commit_msg:
                 msgs = []
 
@@ -406,7 +409,8 @@ class WorkingRepo(Repo):
                         updated, removed)]
 
         try:
-            self.patch_repo.commit(msgs=msgs, template=template)
+            if not no_commit:
+                self.patch_repo.commit(msgs=msgs, template=template)
         finally:
             if template:
                 os.unlink(template)

--- a/plypatch/cli.py
+++ b/plypatch/cli.py
@@ -162,12 +162,15 @@ class RestoreCommand(CLICommand):
     def add_arguments(self, subparser):
         subparser.add_argument('-m', '--message', action='store_true',
                                help='Prompt for a custom commit message')
+        subparser.add_argument('-n', '--no-commit', action='store_true',
+                               help='Don\'t make a commit in the patch repo')
 
     def do(self, args):
         """Apply the patch series to the the current branch of the
         working-repo"""
         try:
-            self.working_repo.restore(customize_commit_msg=args.message)
+            self.working_repo.restore(customize_commit_msg=args.message,
+                                      no_commit=args.no_commit)
         except plypatch.exc.GitConfigRequired as e:
             die("Required git config '%s' is unset." % e)
         except plypatch.exc.RestoreInProgress:


### PR DESCRIPTION
That commit can cause problems when using ply with some automation systems.